### PR TITLE
Mejora para el target test en Makefile que permita restaurar el archivo .env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,10 @@ build: tools ## Construcción de artefactos
 	@chmod +x $(SRC_SCRIPTS) src/script_principal.sh 2>/dev/null || true
 
 test: build ## Ejecución de pruebas
+	@cp .env .env.backup
 	@echo "Ejecutando suite de pruebas..."
-	@bats $(TESTS_SCRIPTS)
+	@trap 'mv .env.backup .env' EXIT; \
+	bats $(TESTS_SCRIPTS)
 
 run: build ## Ejecución del scaneo a repositorio
 	@$(SRC_DIR)/script_principal.sh


### PR DESCRIPTION
## Resumen
Se implementa un mecanismo de trap en el target `test` del Makefile para garantizar que el archivo `.env` siempre sea restaurado desde su backup, incluso si las pruebas fallan o son interrumpidas.

## Cambios hechos

- Se añadió un `trap` que ejecuta la restauración del archivo `.env` al finalizar la ejecución, sin importar si las pruebas terminan exitosamente o con error
- Esto previene que el archivo `.env.backup` quede huérfano en caso de fallo durante la ejecución de las pruebas con `bats`
- Se mejora la robustez del proceso de testing al asegurar que el entorno siempre vuelve a su estado origina