### PR TITLE
Agrega el link del video del Sprint 3

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -118,8 +118,8 @@ MAX_COMMIT_LENGTH="72"
 - `prereceive-violations.txt` - Violaciones servidor
 
 ### dist/ - Distribución
-- `repository-analyzer.tar.gz` - Paquete comprimido
-- `repository-analyzer.tar.gz.sha256` - Hash verificación
+- `repository-analyzer.tar` - Paquete comprimido
+- `repository-analyzer.tar.gz` - Hash verificación
 
 **Ver detalles completos:** [contrato-salidas.md](contrato-salidas.md)
 
@@ -219,8 +219,9 @@ curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/rate_limit
 
 ## Videos
 
-- **Sprint 1**: https://drive.google.com/file/d/1fqYnsCZnfsgDeEsjv6wa4pGi-QOg0N5b/view
-- **Sprint 2**: https://drive.google.com/file/d/1Zcv8O-uDKIOaHMF2lkUxyB15OZWzdv-E/view
+- **Sprint 1**: https://drive.google.com/file/d/1fqYnsCZnfsgDeEsjv6wa4pGi-QOg0N5b/view?usp=sharing
+- **Sprint 2**: https://drive.google.com/file/d/1Zcv8O-uDKIOaHMF2lkUxyB15OZWzdv-E/view?usp=sharing
+- **Sprint 3**: https://drive.google.com/file/d/17A4giCqg0BQUqFkHOPaWQttwHC4tnhCC/view?usp=sharing
 
 ---
 

--- a/docs/contrato-salidas.md
+++ b/docs/contrato-salidas.md
@@ -28,8 +28,8 @@ out/
 └── processed/                    # Reservado para datos procesados
 
 dist/
-├── repository-analyzer.tar.gz    # Paquete de distribución
-└── repository-analyzer.tar.gz.sha256  # Hash SHA256 (pendiente)
+├── repository-analyzer.tar    # Paquete de distribución en tar
+└── repository-analyzer.tar.gz  # Paquete de distribución en tar.gz
 ```
 
 ---
@@ -83,8 +83,8 @@ dist/
 
 | Archivo | Formato | Contenido | Generación | Validación |
 |---------|---------|-----------|------------|------------|
+| `repository-analyzer.tar` | TAR | src/, tests/, git-hooks/, Makefile, README.md, .env.example | `make pack` | `tar -tzf dist/repository-analyzer.tar \| head` |
 | `repository-analyzer.tar.gz` | TAR.GZ | src/, tests/, git-hooks/, Makefile, README.md, .env.example | `make pack` | `tar -tzf dist/repository-analyzer.tar.gz \| head` |
-| `repository-analyzer.tar.gz.sha256` | Texto | Hash SHA256 del paquete | `sha256sum` | `sha256sum -c dist/repository-analyzer.tar.gz.sha256` |
 
 ---
 


### PR DESCRIPTION
## Resumen

En este pequeño pull request agregarmos el link del video de la exposición del Sprint 3 y corregimos errores en los archivos README.md y  contrato-salidas.md